### PR TITLE
SSDESKTOP-1994 : update dockerfile with new version and folder name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:11.13
 
-ENV ELECTRON_SYMBOL_VERSION=3.0.10
+ENV ELECTRON_SYMBOL_VERSION=5.0.8
 
 RUN mkdir /symbols && mkdir -p /app/pool/symbols
 
 WORKDIR /symbols
 
-RUN curl -L -o darwin.x64.zip https://github.com/electron/electron/releases/download/v${ELECTRON_SYMBOL_VERSION}/electron-v${ELECTRON_SYMBOL_VERSION}-darwin-x64-symbols.zip && unzip darwin.x64.zip && mv electron.breakpad.syms/* /app/pool/symbols && rm -rf ./*
+RUN curl -L -o darwin.x64.zip https://github.com/electron/electron/releases/download/v${ELECTRON_SYMBOL_VERSION}/electron-v${ELECTRON_SYMBOL_VERSION}-darwin-x64-symbols.zip && unzip darwin.x64.zip && mv breakpad_symbols/* /app/pool/symbols && rm -rf ./*
 
-RUN curl -L -o win32.zip https://github.com/electron/electron/releases/download/v${ELECTRON_SYMBOL_VERSION}/electron-v${ELECTRON_SYMBOL_VERSION}-win32-ia32-symbols.zip && unzip win32.zip && mv electron.breakpad.syms/* /app/pool/symbols && rm -rf ./*
+RUN curl -L -o win32.zip https://github.com/electron/electron/releases/download/v${ELECTRON_SYMBOL_VERSION}/electron-v${ELECTRON_SYMBOL_VERSION}-win32-ia32-symbols.zip && unzip win32.zip && mv breakpad_symbols/* /app/pool/symbols && rm -rf ./*
 
 RUN npm install -g grunt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-breakpad-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
I don't think we're going to try and maintain backwards compatibility with Electron 3 as we'll just push everyone to Electron 5 anyways.