### PR TITLE
Ssdesktop 2477 redeploy mini breakpad server for electron 7

### DIFF
--- a/electron_versions.txt
+++ b/electron_versions.txt
@@ -2,3 +2,4 @@
 5.0.8 breakpad_symbols
 5.0.11 breakpad_symbols
 7.1.2 breakpad_symbols
+7.1.9 breakpad_symbols

--- a/electron_versions_runner.sh
+++ b/electron_versions_runner.sh
@@ -2,6 +2,7 @@
 mkdir -p symbols && cd symbols
 while IFS=" " read version directory; do
   curl -L -o darwin.x64.zip "https://github.com/electron/electron/releases/download/v$version/electron-v$version-darwin-x64-symbols.zip" && unzip darwin.x64.zip && rsync -a "$directory"/ /app/pool/symbols && rm -rf ./*
-  curl -L -o win32.zip "https://github.com/electron/electron/releases/download/v$version/electron-v$version-win32-ia32-symbols.zip" && unzip win32.zip && rsync -a "$directory"/ /app/pool/symbols && rm -rf ./*
+  curl -L -o win32.ia32.zip "https://github.com/electron/electron/releases/download/v$version/electron-v$version-win32-ia32-symbols.zip" && unzip win32.ia32.zip && rsync -a "$directory"/ /app/pool/symbols && rm -rf ./*
+  curl -L -o win32.x64.zip "https://github.com/electron/electron/releases/download/v$version/electron-v$version-win32-x64-symbols.zip" && unzip win32.x64.zip && rsync -a "$directory"/ /app/pool/symbols && rm -rf ./*
 done < ../electron_versions.txt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-breakpad-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2192,9 +2192,9 @@
       }
     },
     "minidump": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/minidump/-/minidump-0.15.0.tgz",
-      "integrity": "sha512-US/2hFP+shYZ9YFjULBq2Q6MKZvjnl8hE65STRRFMKQIqV9UWxAZrp5QDVbvkh8AnDoQO6kUQtS0eCTdnADnDw=="
+      "version": "0.19.0",
+      "resolved": "https://artifactory.pgi-tools.com/artifactory/api/npm/npm/minidump/-/minidump-0.19.0.tgz",
+      "integrity": "sha1-06Ll6ghGPEVAFwfq8Ci6qk8glgc="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mini-breakpad-server",
   "description": "Minimum breakpad crash reports collecting server",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "bin": {
     "mini-breakpad-server": "bin/mini-breakpad-server"
   },
@@ -21,7 +21,7 @@
     "github-releases": "0.4.2",
     "glob": "^7.0.0",
     "method-override": "^3.0.0",
-    "minidump": "0.15.0",
+    "minidump": "0.19.0",
     "mkdirp": "~0.3.5",
     "pug": "^2.0.0",
     "uuid": "^3.0.0",


### PR DESCRIPTION
Needed a new minidump version in order to read the more recent symbol files Electron was producing. Additionally, we anticipate releasing x64 versions of the desktop and we will extract symbols for both windows architectures going forward.