### PR TITLE
Update index with additional information and nicer layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-breakpad-server",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mini-breakpad-server",
   "description": "Minimum breakpad crash reports collecting server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "bin": {
     "mini-breakpad-server": "bin/mini-breakpad-server"
   },

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,9 +1,23 @@
 extends layout
 
 block content
+  style
+    include table.css
   h1= title
-  ol
+  table
+    tr
+      th id
+      th Electron Version
+      th OS
+      th Product
+      th Product Version
+      th Time
     each record in records
-      li
-        a(href='view/' + record.id)
-          = 'v' + record.fields._version + ' ' + record.fields.platform + ' ' + record.time.toLocaleString()
+      tr
+        td
+          a(href='view/' + record.id)=record.id
+        td= record.version
+        td= record.fields.platform
+        td= record.fields._productName
+        td= record.fields._version
+        td= record.time.toLocaleString()

--- a/views/table.css
+++ b/views/table.css
@@ -1,0 +1,12 @@
+table {
+  width: 100%;
+}
+
+tr:nth-child(even) {
+  background-color: #f2f2f2;
+}
+
+th,
+td {
+  text-align: left;
+}


### PR DESCRIPTION
We were missing some important data from the index for quickly identifying crash reports as well as using a concatenated layout which makes it difficult to find reports.  This PR adds additional data and uses a table to make the view easier to read.